### PR TITLE
Specified devices for inverter.py

### DIFF
--- a/didgen/inverter.py
+++ b/didgen/inverter.py
@@ -220,10 +220,6 @@ def initialize(config, output, i, device="cpu"):
         
         fea_h, adj_vec = start_from(dataset[qmid].to(device), config)
 
-        mask = (adj_vec == 0)
-        mask_mask = (torch.rand(mask.shape) > 0.15).to(device)
-        config.adj_mask = ~(mask * mask_mask)
-        
         # nudge
 
         N = config.max_size

--- a/didgen/inverter.py
+++ b/didgen/inverter.py
@@ -221,7 +221,7 @@ def initialize(config, output, i, device="cpu"):
         fea_h, adj_vec = start_from(dataset[qmid].to(device), config)
 
         mask = (adj_vec == 0)
-        mask_mask = (torch.rand(mask.shape) > 0.15)
+        mask_mask = (torch.rand(mask.shape) > 0.15).to(device)
         config.adj_mask = ~(mask * mask_mask)
         
         # nudge
@@ -420,15 +420,15 @@ def invert(model, fea_h, adj_vec, config, output):
                 
                 adj_indices = -torch.ones((N,N), device=adj_vec.device, dtype=torch.long)
                 
-                adj_indices[tidx[0],tidx[1]] = torch.arange(adj_vec.shape[0])
+                adj_indices[tidx[0],tidx[1]] = torch.arange(adj_vec.shape[0], device=adj_vec.device)
                 
-                adj_indices[tidx[1],tidx[0]] = torch.arange(adj_vec.shape[0])
+                adj_indices[tidx[1],tidx[0]] = torch.arange(adj_vec.shape[0], device=adj_vec.device)
             
                 adj_diff = torch.round(adj_tmp - adj)
                 
                 adj_overflow = torch.round(adj_sum - 4)
                 
-                adj_culprits = torch.zeros(adj.shape)
+                adj_culprits = torch.zeros(adj.shape, device=adj_vec.device)
             
                 # Less than 4 bonds ------------
             
@@ -436,7 +436,7 @@ def invert(model, fea_h, adj_vec, config, output):
                 
                 sorted_culprits, indices_x = torch.sort(adj_culprits, dim=2)
                 
-                indices_y = torch.arange(N).unsqueeze(1).expand(N,N).unsqueeze(0)
+                indices_y = torch.arange(N, device=adj_vec.device).unsqueeze(1).expand(N,N).unsqueeze(0)
                 
                 cumsum = torch.cumsum(sorted_culprits, dim=2)
                 


### PR DESCRIPTION
I had a litle problem while running the `examples/test_CGCNN.sh` script. The model was trained well, but when I tried to invert it, I had several exceptions `RuntimeError: Expected all tensors to be on the same device`. Upon inspection, I have found that ome torch tensors did not have their devices specified, so I ave mage the following fixes:

In line 224 of `didgen/inverter.py`, `mask_mask` is now sent to `device`
In lines 423 and 425, `adj_indices` are now set using arrays created on the same device as adjacency vectors `torch.arange(adj_vec.shape[0], device=adj_vec.device)`
In line 431, same logic for `adj_culprits`
In line 439, same logic for `indices_y`

This appeared to fix the problems I had